### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "command-line task management utility for work"
 license = "MIT"
 categories = ["command-line-utilities"]
+repository = "https://github.com/satake0916/sigotorrior"
 
 [dependencies]
 chrono = "0.4.38"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.